### PR TITLE
Add new incorrect implementation

### DIFF
--- a/Challenge/IncorrectImplementations/DoNotOpen.cs
+++ b/Challenge/IncorrectImplementations/DoNotOpen.cs
@@ -366,5 +366,19 @@ namespace Challenge.IncorrectImplementations
         }
     }
 
+    [IncorrectImplementation]
+    public class WordsStatistics_EN2 : WordsStatistics
+	{
+        private List<Tuple<int, string>> result;
+
+        public override IEnumerable<Tuple<int, string>> GetStatistics()
+        {
+            return result ?? (result = stats.OrderByDescending(kv => kv.Value)
+                .ThenBy(kv => kv.Key)
+                .Select(kv => Tuple.Create(kv.Value, kv.Key))
+                .ToList());
+        }
+    }
+
 	#endregion
 }

--- a/Challenge/IncorrectImplementations/DoNotOpen.cs
+++ b/Challenge/IncorrectImplementations/DoNotOpen.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Challenge.Infrastructure;
@@ -339,6 +340,32 @@ namespace Challenge.IncorrectImplementations
 			}
 		}
 	}
+
+    [IncorrectImplementation]
+    public class WordsStatistics_EN : IWordsStatistics
+	{
+        private IDictionary<string, int> stats
+            = new Dictionary<string, int>();
+
+        public void AddWord(string word)
+        {
+            if (word == null) throw new ArgumentNullException(nameof(word));
+            if (string.IsNullOrWhiteSpace(word)) return;
+            if (word.Length > 10)
+                word = word.Substring(0, 10);
+            int count;
+            stats[word.ToLower()] = stats.TryGetValue(word.ToLower(), out count) ? count + 1 : 1;
+        }
+
+        public IEnumerable<Tuple<int, string>> GetStatistics()
+        {
+            var temp = stats;
+            stats = new Dictionary<string, int>();
+            return temp.OrderByDescending(kv => kv.Value)
+                .ThenBy(kv => kv.Key)
+                .Select(kv => Tuple.Create(kv.Value, kv.Key));
+        }
+    }
 
 	#endregion
 }

--- a/Challenge/IncorrectImplementations/DoNotOpen.cs
+++ b/Challenge/IncorrectImplementations/DoNotOpen.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Challenge.Infrastructure;

--- a/Challenge/IncorrectImplementations/DoNotOpen.cs
+++ b/Challenge/IncorrectImplementations/DoNotOpen.cs
@@ -373,10 +373,7 @@ namespace Challenge.IncorrectImplementations
 
         public override IEnumerable<Tuple<int, string>> GetStatistics()
         {
-            return result ?? (result = stats.OrderByDescending(kv => kv.Value)
-                .ThenBy(kv => kv.Key)
-                .Select(kv => Tuple.Create(kv.Value, kv.Key))
-                .ToList());
+            return result ?? (result = base.GetStatistics().ToList());
         }
     }
 

--- a/Challenge/Infrastructure/IncorrectImplementations_Tests.cs
+++ b/Challenge/Infrastructure/IncorrectImplementations_Tests.cs
@@ -55,6 +55,7 @@ namespace Challenge.Infrastructure
     public class WordsStatistics_999_Tests : IncorrectImplementation_TestsBase { }
     public class WordsStatistics_QWE_Tests : IncorrectImplementation_TestsBase { }
     public class WordsStatistics_STA_Tests : IncorrectImplementation_TestsBase { }
+    public class WordsStatistics_EN_Tests : IncorrectImplementation_TestsBase { }
 
     #endregion
 }

--- a/Challenge/Infrastructure/IncorrectImplementations_Tests.cs
+++ b/Challenge/Infrastructure/IncorrectImplementations_Tests.cs
@@ -56,6 +56,7 @@ namespace Challenge.Infrastructure
     public class WordsStatistics_QWE_Tests : IncorrectImplementation_TestsBase { }
     public class WordsStatistics_STA_Tests : IncorrectImplementation_TestsBase { }
     public class WordsStatistics_EN_Tests : IncorrectImplementation_TestsBase { }
+    public class WordsStatistics_EN2_Tests : IncorrectImplementation_TestsBase { }
 
     #endregion
 }


### PR DESCRIPTION
Implementation with incorrect .GetStatistics()
EN: Does not support multiple enumeration
EN2: Cache first .GetStatistics() result
