### PR TITLE
fix misspelling

### DIFF
--- a/HomeExercises/NumberValidatorTests.cs
+++ b/HomeExercises/NumberValidatorTests.cs
@@ -45,7 +45,7 @@ namespace HomeExercises
 			if (precision <= 0)
 				throw new ArgumentException("precision must be a positive number");
 			if (scale < 0 || scale >= precision)
-				throw new ArgumentException("precision must be a non-negative number less or equal than precision");
+				throw new ArgumentException("scale must be a non-negative number less than precision");
 			numberRegex = new Regex(@"^([+-]?)(\d+)([.,](\d+))?$", RegexOptions.IgnoreCase);
 		}
 


### PR DESCRIPTION
В описании исключения была опечатка и оно не соответствовало условию его возникновения